### PR TITLE
Fix flaky email subject test by pinning round date

### DIFF
--- a/tests/email/test_base.py
+++ b/tests/email/test_base.py
@@ -1,3 +1,4 @@
+import datetime
 from textwrap import dedent
 from unittest.mock import patch
 
@@ -21,6 +22,7 @@ def round_config():
     return RoundConfig(
         number=3,
         people=people,
+        date=datetime.date(2023, 11, 1),
         overrides=overrides,
     )
 


### PR DESCRIPTION
## What changed

`tests/email/test_base.py::test_render_messages` asserted the rendered subject was `"Colette Round 3 (Nov)"`, but the `round_config` fixture never set a `date`. This made the test flaky — it only passed in November and failed every other month (e.g. `"(Jun)"` currently).

The fix pins the fixture's round date to a fixed November date:

```python
date=datetime.date(2023, 11, 1),
```

## Why

The production code is already correct and deterministic: `render_messages` renders `subject.txt` with `round_config` in scope, and the template derives the month from `round_config.date.strftime('%b')` — i.e. the round's configured date, not the current date.

The flakiness came entirely from the test fixture. `RoundConfig.date` defaults to `datetime.date.today()` (`colette/models.py:120`), and the fixture never overrode it, so the rendered month tracked whatever month the test happened to run in.

Rather than weaken the production `today()` default to paper over the assertion, this pins the fixture to a deterministic November date so the existing `"(Nov)"` expectation holds year-round and the test exercises real production behavior.

## Notes for reviewer

- Change is minimal (added `import datetime` and one `date=` kwarg); no whole-file reformatting, matching existing in-file style.
- `uv run pytest tests/email/test_base.py` → `2 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)