### PR TITLE
Default to today's date for `new`

### DIFF
--- a/colette/__main__.py
+++ b/colette/__main__.py
@@ -1,5 +1,6 @@
 import argparse
 import configparser
+import datetime
 import os
 import re
 import sys
@@ -69,7 +70,7 @@ def email(path: PathLike, round: int = None, preview=True):
 
 def new_round_config(path: PathLike, date: str = None):
     if date is None:
-        date = input("Date of next round (YYYY-MM-DD): ")
+        date = datetime.date.today().isoformat()
 
     date = tomlkit.date(date.strip())
 
@@ -203,7 +204,8 @@ def main():
     )
     new_parser.add_argument(
         "date",
-        help="date of the next round (YYYY-MM-DD)",
+        nargs="?",
+        help="date of the next round (YYYY-MM-DD); defaults to today",
     )
     new_parser.set_defaults(func=new_round_config)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -37,6 +37,35 @@ def test_new_round_config_without_previous_remove_block(tmp_path):
     assert created_config["date"] == datetime.date(2026, 5, 8)
 
 
+def test_new_round_config_defaults_to_today(tmp_path):
+    # Regression test for #16
+    (tmp_path / "people.csv").write_text(dedent("""\
+            name,organisation,email,active
+            Alice,Org1,alice@example.com,True
+            Bob,Org2,bob@example.com,True
+            """))
+
+    (tmp_path / "solution_000001.toml").write_text(dedent("""\
+            cost = 0
+            round = 1
+
+            [[pair]]
+            primary = "Alice"
+            secondary = "Bob"
+            """))
+
+    (tmp_path / "round_000001.toml").write_text(dedent("""\
+            number = 1
+            date = 2026-05-01
+            """))
+
+    new_round_config(tmp_path)
+
+    created_config = tomlkit.parse((tmp_path / "round_000002.toml").read_text())
+    assert created_config["number"] == 2
+    assert created_config["date"] == datetime.date.today()
+
+
 def test_new_round_config_invalid_remove_until_raises_value_error(tmp_path):
     # Regression test for #20: an invalid 'until' value must raise a clear
     # ValueError, not blow up with a secondary exception (e.g. NameError) while


### PR DESCRIPTION
## What

`colette new` no longer requires a `date` argument. When omitted, it now defaults to today's date.

## Why

Fixes #16. The `date` positional argument was required, which meant the `input()` prompt fallback inside `new_round_config` was effectively dead code. Defaulting to today is the common case (you usually create the round config for the round happening now/imminently) and removes friction.

## Changes

- `colette/__main__.py`
  - Added `import datetime`.
  - `new_round_config` now defaults `date` to today (`datetime.date.today().isoformat()`) when not provided, instead of prompting.
  - Made the `date` CLI argument optional (`nargs="?"`) with updated help text: *"date of the next round (YYYY-MM-DD); defaults to today"*.
- `tests/test_main.py`
  - Added `test_new_round_config_defaults_to_today` covering the new default.

## Verification

- `colette new` (no date) → creates the round dated today.
- `colette new 2026-07-15` → still uses the explicit date.
- `colette new --help` → shows `[date]` as optional.
- Full test suite: 27 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)